### PR TITLE
Support additional slave arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ class PythonSlave(Fmi2Slave):
     author = "John Doe"
     description = "A simple description"
 
-    def __init__(self, instance_name):
-        super().__init__(instance_name)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
         self.intOut = 1
         self.realOut = 3.0

--- a/pythonfmu/builder.py
+++ b/pythonfmu/builder.py
@@ -50,7 +50,7 @@ class ModelDescriptionFetcher:
             spec.loader.exec_module(fmu_interface)
             # Instantiate the interface
             class_name = getattr(fmu_interface, "slave_class")
-            instance = getattr(fmu_interface, class_name)("dummyInstance")
+            instance = getattr(fmu_interface, class_name)(dict(instance_name="dummyInstance"))
         finally:
             sys.path.remove(str(filepath.parent))  # remove inserted temporary path
         

--- a/pythonfmu/builder.py
+++ b/pythonfmu/builder.py
@@ -50,7 +50,7 @@ class ModelDescriptionFetcher:
             spec.loader.exec_module(fmu_interface)
             # Instantiate the interface
             class_name = getattr(fmu_interface, "slave_class")
-            instance = getattr(fmu_interface, class_name)(dict(instance_name="dummyInstance"))
+            instance = getattr(fmu_interface, class_name)("dummyInstance")
         finally:
             sys.path.remove(str(filepath.parent))  # remove inserted temporary path
         

--- a/pythonfmu/builder.py
+++ b/pythonfmu/builder.py
@@ -50,7 +50,7 @@ class ModelDescriptionFetcher:
             spec.loader.exec_module(fmu_interface)
             # Instantiate the interface
             class_name = getattr(fmu_interface, "slave_class")
-            instance = getattr(fmu_interface, class_name)("dummyInstance")
+            instance = getattr(fmu_interface, class_name)(instance_name="dummyInstance")
         finally:
             sys.path.remove(str(filepath.parent))  # remove inserted temporary path
 

--- a/pythonfmu/fmi2slave.py
+++ b/pythonfmu/fmi2slave.py
@@ -34,9 +34,9 @@ class Fmi2Slave(ABC):
     modelName: ClassVar[Optional[str]] = None
     description: ClassVar[Optional[str]] = None
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, **kwargs):
         self.vars = OrderedDict()
-        self.instance_name = args[0]
+        self.instance_name = kwargs["instance_name"]
 
         self.visible = kwargs.get("visible", False)
 

--- a/pythonfmu/fmi2slave.py
+++ b/pythonfmu/fmi2slave.py
@@ -31,9 +31,19 @@ class Fmi2Slave(ABC):
     modelName: ClassVar[Optional[str]] = None
     description: ClassVar[Optional[str]] = None
 
-    def __init__(self, instance_name: str):
+    def __init__(self, args: Dict):
         self.vars = OrderedDict()
-        self.instance_name = instance_name
+
+        if "instance_name" in args.keys():
+            self.instance_name = args["instance_name"]
+        else:
+            raise Exception(f"Required key 'instance_name' not provided!")
+
+        if "visible" in args.keys():
+            self.visible = args["visible"]
+        else:
+            self.visible = False
+
         if self.__class__.modelName is None:
             self.__class__.modelName = self.__class__.__name__
 

--- a/pythonfmu/fmi2slave.py
+++ b/pythonfmu/fmi2slave.py
@@ -31,17 +31,13 @@ class Fmi2Slave(ABC):
     modelName: ClassVar[Optional[str]] = None
     description: ClassVar[Optional[str]] = None
 
-    def __init__(self, args: Dict):
+    def __init__(self, *args, **kwargs):
         self.vars = OrderedDict()
-
-        if "instance_name" in args.keys():
-            self.instance_name = args["instance_name"]
-        else:
-            raise Exception("Required key 'instance_name' not provided!")
+        self.instance_name = args[0]
 
         self.visible = False
-        if "visible" in args.keys():
-            self.visible = args["visible"]
+        if "visible" in kwargs:
+            self.visible = kwargs["visible"]
 
         if self.__class__.modelName is None:
             self.__class__.modelName = self.__class__.__name__

--- a/pythonfmu/fmi2slave.py
+++ b/pythonfmu/fmi2slave.py
@@ -38,9 +38,7 @@ class Fmi2Slave(ABC):
         self.vars = OrderedDict()
         self.instance_name = args[0]
 
-        self.visible = False
-        if "visible" in kwargs:
-            self.visible = kwargs["visible"]
+        self.visible = kwargs.get("visible", False)
 
         if self.__class__.modelName is None:
             self.__class__.modelName = self.__class__.__name__

--- a/pythonfmu/fmi2slave.py
+++ b/pythonfmu/fmi2slave.py
@@ -37,12 +37,11 @@ class Fmi2Slave(ABC):
         if "instance_name" in args.keys():
             self.instance_name = args["instance_name"]
         else:
-            raise Exception(f"Required key 'instance_name' not provided!")
+            raise Exception("Required key 'instance_name' not provided!")
 
+        self.visible = False
         if "visible" in args.keys():
             self.visible = args["visible"]
-        else:
-            self.visible = False
 
         if self.__class__.modelName is None:
             self.__class__.modelName = self.__class__.__name__

--- a/pythonfmu/pythonfmu-export/cpp/PyObjectWrapper.cpp
+++ b/pythonfmu/pythonfmu-export/cpp/PyObjectWrapper.cpp
@@ -63,9 +63,9 @@ PyObjectWrapper::PyObjectWrapper(const std::string& instanceName, const bool vis
         handle_py_exception("[ctor] PyObject_GetAttr");
     }
 
-    PyObject* args = Py_BuildValue("s", instanceName.c_str());
-    PyObject* kwargs = Py_BuildValue("{si}", "visible", visible);
-    pInstance_ = PyObject_CallFunctionObjArgs(pClass, args, kwargs, nullptr);
+    PyObject* args = PyTuple_New(0);
+    PyObject* kwargs = Py_BuildValue("{sssi}", "instance_name", instanceName.c_str(), "visible", visible);
+    pInstance_ = PyObject_Call(pClass, args, kwargs);
     Py_DECREF(args);
     Py_DECREF(kwargs);
     Py_DECREF(pClass);

--- a/pythonfmu/pythonfmu-export/cpp/PyObjectWrapper.cpp
+++ b/pythonfmu/pythonfmu-export/cpp/PyObjectWrapper.cpp
@@ -26,7 +26,7 @@ inline std::string getline(const std::string& fileName)
 namespace pythonfmu
 {
 
-PyObjectWrapper::PyObjectWrapper(const std::string& instanceName, const std::string& resources)
+PyObjectWrapper::PyObjectWrapper(const std::string& instanceName, const bool visible, const bool loggingOn, const std::string& resources)
     : instanceName_(instanceName)
 {
     // Append resources path to python sys path
@@ -62,12 +62,13 @@ PyObjectWrapper::PyObjectWrapper(const std::string& instanceName, const std::str
     if (pClass == nullptr) {
         handle_py_exception("[ctor] PyObject_GetAttr");
     }
-    PyObject *argList = Py_BuildValue("s", instanceName.c_str());
-    pInstance_ = PyObject_CallFunctionObjArgs(pClass, argList, nullptr);
-    Py_DECREF(argList);
+
+    PyObject* kwargs = Py_BuildValue("{s:s,s:i}", "instance_name", instanceName.c_str(), "visible", visible);
+    pInstance_ = PyObject_CallFunctionObjArgs(pClass, kwargs, nullptr);
+    Py_DECREF(kwargs);
     Py_DECREF(pClass);
     if (pInstance_ == nullptr) {
-        handle_py_exception("[ctor] PyObject_CallFunctionObjArgs");
+        handle_py_exception("[ctor] PyObject_Call");
     }
 }
 

--- a/pythonfmu/pythonfmu-export/cpp/PyObjectWrapper.cpp
+++ b/pythonfmu/pythonfmu-export/cpp/PyObjectWrapper.cpp
@@ -70,7 +70,7 @@ PyObjectWrapper::PyObjectWrapper(const std::string& instanceName, const bool vis
     Py_DECREF(kwargs);
     Py_DECREF(pClass);
     if (pInstance_ == nullptr) {
-        handle_py_exception("[ctor] PyObject_CallFunctionObjArgs");
+        handle_py_exception("[ctor] PyObject_Call");
     }
 }
 

--- a/pythonfmu/pythonfmu-export/cpp/PyObjectWrapper.cpp
+++ b/pythonfmu/pythonfmu-export/cpp/PyObjectWrapper.cpp
@@ -68,7 +68,7 @@ PyObjectWrapper::PyObjectWrapper(const std::string& instanceName, const bool vis
     Py_DECREF(kwargs);
     Py_DECREF(pClass);
     if (pInstance_ == nullptr) {
-        handle_py_exception("[ctor] PyObject_Call");
+        handle_py_exception("[ctor] PyObject_CallFunctionObjArgs");
     }
 }
 

--- a/pythonfmu/pythonfmu-export/cpp/PyObjectWrapper.cpp
+++ b/pythonfmu/pythonfmu-export/cpp/PyObjectWrapper.cpp
@@ -63,8 +63,10 @@ PyObjectWrapper::PyObjectWrapper(const std::string& instanceName, const bool vis
         handle_py_exception("[ctor] PyObject_GetAttr");
     }
 
-    PyObject* kwargs = Py_BuildValue("{s:s,s:i}", "instance_name", instanceName.c_str(), "visible", visible);
-    pInstance_ = PyObject_CallFunctionObjArgs(pClass, kwargs, nullptr);
+    PyObject* args = Py_BuildValue("s", instanceName.c_str());
+    PyObject* kwargs = Py_BuildValue("{s:i}", "visible", visible);
+    pInstance_ = PyObject_CallFunctionObjArgs(pClass, args, kwargs, nullptr);
+    Py_DECREF(args);
     Py_DECREF(kwargs);
     Py_DECREF(pClass);
     if (pInstance_ == nullptr) {

--- a/pythonfmu/pythonfmu-export/cpp/PyObjectWrapper.cpp
+++ b/pythonfmu/pythonfmu-export/cpp/PyObjectWrapper.cpp
@@ -64,7 +64,7 @@ PyObjectWrapper::PyObjectWrapper(const std::string& instanceName, const bool vis
     }
 
     PyObject* args = Py_BuildValue("s", instanceName.c_str());
-    PyObject* kwargs = Py_BuildValue("{s:i}", "visible", visible);
+    PyObject* kwargs = Py_BuildValue("{si}", "visible", visible);
     pInstance_ = PyObject_CallFunctionObjArgs(pClass, args, kwargs, nullptr);
     Py_DECREF(args);
     Py_DECREF(kwargs);

--- a/pythonfmu/pythonfmu-export/cpp/SlaveInstance.cpp
+++ b/pythonfmu/pythonfmu-export/cpp/SlaveInstance.cpp
@@ -8,8 +8,8 @@
 namespace pythonfmu
 {
 
-SlaveInstance::SlaveInstance(const std::string& instanceName, const std::string& resources)
-    : instance_(PyObjectWrapper(instanceName, resources))
+SlaveInstance::SlaveInstance(const std::string& instanceName, const bool visible, const bool loggingOn, const std::string& resources)
+    : instance_(PyObjectWrapper(instanceName, visible, loggingOn, resources))
 {}
 
 void SlaveInstance::SetupExperiment(cppfmu::FMIBoolean, cppfmu::FMIReal, cppfmu::FMIReal tStart, cppfmu::FMIBoolean, cppfmu::FMIReal)
@@ -95,8 +95,8 @@ cppfmu::UniquePtr<cppfmu::SlaveInstance> CppfmuInstantiateSlave(
     cppfmu::FMIString fmuResourceLocation,
     cppfmu::FMIString,
     cppfmu::FMIReal,
-    cppfmu::FMIBoolean,
-    cppfmu::FMIBoolean,
+    cppfmu::FMIBoolean visible,
+    cppfmu::FMIBoolean loggingOn,
     cppfmu::Memory memory,
     const cppfmu::Logger&)
 {
@@ -117,5 +117,5 @@ cppfmu::UniquePtr<cppfmu::SlaveInstance> CppfmuInstantiateSlave(
     }
 
     return cppfmu::AllocateUnique<pythonfmu::SlaveInstance>(
-        memory, instanceName, resources);
+        memory, instanceName, visible, loggingOn, resources);
 }

--- a/pythonfmu/pythonfmu-export/headers/pythonfmu/PyObjectWrapper.hpp
+++ b/pythonfmu/pythonfmu-export/headers/pythonfmu/PyObjectWrapper.hpp
@@ -13,7 +13,7 @@ class PyObjectWrapper
 {
 
 public:
-    PyObjectWrapper(const std::string& instanceName, const std::string& resources);
+    PyObjectWrapper(const std::string& instanceName, bool visible, bool loggingOn, const std::string& resources);
 
     void setupExperiment(double startTime);
 

--- a/pythonfmu/pythonfmu-export/headers/pythonfmu/SlaveInstance.hpp
+++ b/pythonfmu/pythonfmu-export/headers/pythonfmu/SlaveInstance.hpp
@@ -16,7 +16,7 @@ class SlaveInstance : public cppfmu::SlaveInstance
 {
 
 public:
-    SlaveInstance(const std::string& instanceName, const std::string& resources);
+    SlaveInstance(const std::string& instanceName, bool visible, bool loggingOn, const std::string& resources);
 
     void SetupExperiment(cppfmu::FMIBoolean toleranceDefined, cppfmu::FMIReal tolerance, cppfmu::FMIReal tStart, cppfmu::FMIBoolean stopTimeDefined, cppfmu::FMIReal tStop) override;
     void EnterInitializationMode() override;

--- a/pythonfmu/tests/pythonslave.py
+++ b/pythonfmu/tests/pythonslave.py
@@ -8,8 +8,8 @@ class PythonSlave(Fmi2Slave):
     author = "John Doe"
     description = "A simple description"
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
 
         self.intParam = 42
         self.intOut = 23

--- a/pythonfmu/tests/pythonslave.py
+++ b/pythonfmu/tests/pythonslave.py
@@ -8,8 +8,8 @@ class PythonSlave(Fmi2Slave):
     author = "John Doe"
     description = "A simple description"
 
-    def __init__(self, instance_name):
-        super().__init__(instance_name)
+    def __init__(self, args):
+        super().__init__(args)
 
         self.intParam = 42
         self.intOut = 23

--- a/pythonfmu/tests/pythonslave.py
+++ b/pythonfmu/tests/pythonslave.py
@@ -8,8 +8,8 @@ class PythonSlave(Fmi2Slave):
     author = "John Doe"
     description = "A simple description"
 
-    def __init__(self, args):
-        super().__init__(args)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
         self.intParam = 42
         self.intOut = 23

--- a/pythonfmu/tests/test_fmi2slave.py
+++ b/pythonfmu/tests/test_fmi2slave.py
@@ -17,20 +17,23 @@ PY2FMI = dict([(v, k) for k, v in FMI2PY.items()])
 def test_Fmi2Slave_constructor(model):
 
     class Slave(Fmi2Slave):
+
         modelName = model
 
-        def __init__(self, args):
-            super().__init__(args)
+        def __init__(self, instance_name):
+            super().__init__(instance_name)
 
         def do_step(self, t, dt):
             return True
 
     if model is None:
-        _ = Slave(dict(instance_name="slaveInstance"))
+        slave = Slave("slaveInstance")
         assert Slave.modelName == "Slave"
+        assert slave.instance_name == "slaveInstance"
     else:
-        _ = Slave(dict(instance_name="slaveInstance"))
+        slave = Slave("slaveInstance")
         assert Slave.modelName == model
+        assert slave.instance_name == "slaveInstance"
 
 @pytest.mark.parametrize("fmi_type", FMI2PY)
 @pytest.mark.parametrize("value", [

--- a/pythonfmu/tests/test_fmi2slave.py
+++ b/pythonfmu/tests/test_fmi2slave.py
@@ -42,8 +42,9 @@ def test_Fmi2Slave_constructor(model):
 def test_Fmi2Slave_getters(fmi_type, value):
     
     class Slave(Fmi2Slave):
-        def __init__(self, args):
-            super().__init__(args)
+
+        def __init__(self, instance_name):
+            super().__init__(instance_name)
             self.var = value
             self.register_variable(PY2FMI[type(value)]("var"))
 
@@ -53,7 +54,7 @@ def test_Fmi2Slave_getters(fmi_type, value):
     py_type = FMI2PY[fmi_type]
     fmi_type_name = fmi_type.__qualname__.lower()
 
-    slave = Slave(dict(instance_name="slaveInstance"))
+    slave = Slave("slaveInstance")
     if type(value) is py_type:
         assert getattr(slave, f"get_{fmi_type_name}")([0, ]) == [value, ]
     else:
@@ -71,15 +72,16 @@ def test_Fmi2Slave_getters(fmi_type, value):
 def test_Fmi2Slave_setters(fmi_type, value):
 
     class Slave(Fmi2Slave):
-        def __init__(self, args):
-            super().__init__(args)
+
+        def __init__(self, instance_name):
+            super().__init__(instance_name)
             self.var = None
             self.register_variable(PY2FMI[type(value)]("var"))
 
         def do_step(self, t, dt):
             return True
     
-    slave = Slave(dict(instance_name="slaveInstance"))
+    slave = Slave("slaveInstance")
     py_type = FMI2PY[fmi_type]
     fmi_type_name = fmi_type.__qualname__.lower()
 

--- a/pythonfmu/tests/test_fmi2slave.py
+++ b/pythonfmu/tests/test_fmi2slave.py
@@ -17,14 +17,18 @@ PY2FMI = dict([(v, k) for k, v in FMI2PY.items()])
 def test_Fmi2Slave_constructor(model):
     class Slave(Fmi2Slave):
         modelName = model
+
+        def __init__(self, args):
+            super().__init__(args)
+
         def do_step(self, t, dt):
             return True
 
     if model is None:
-        _ = Slave("instanceSlave")
+        _ = Slave(dict(instance_name="slaveInstance"))
         assert Slave.modelName == "Slave"
     else:
-        _ = Slave("instanceSlave")
+        _ = Slave(dict(instance_name="slaveInstance"))
         assert Slave.modelName == model
 
 @pytest.mark.parametrize("fmi_type", FMI2PY)

--- a/pythonfmu/tests/test_fmi2slave.py
+++ b/pythonfmu/tests/test_fmi2slave.py
@@ -41,8 +41,8 @@ def test_Fmi2Slave_constructor(model):
 def test_Fmi2Slave_getters(fmi_type, value):
     
     class Slave(Fmi2Slave):
-        def __init__(self, instance_name):
-            super().__init__(instance_name)
+        def __init__(self, args):
+            super().__init__(args)
             self.var = value
             self.register_variable(PY2FMI[type(value)]("var"))
 
@@ -52,7 +52,7 @@ def test_Fmi2Slave_getters(fmi_type, value):
     py_type = FMI2PY[fmi_type]
     fmi_type_name = fmi_type.__qualname__.lower()
 
-    slave = Slave("instanceSlave")
+    slave = Slave(dict(instance_name="slaveInstance"))
     if type(value) is py_type:
         assert getattr(slave, f"get_{fmi_type_name}")([0, ]) == [value, ]
     else:
@@ -69,15 +69,15 @@ def test_Fmi2Slave_getters(fmi_type, value):
 ])
 def test_Fmi2Slave_setters(fmi_type, value):
     class Slave(Fmi2Slave):
-        def __init__(self, instance_name):
-            super().__init__(instance_name)
+        def __init__(self, args):
+            super().__init__(args)
             self.var = None
             self.register_variable(PY2FMI[type(value)]("var"))
 
         def do_step(self, t, dt):
             return True
     
-    slave = Slave("instanceSlave")
+    slave = Slave(dict(instance_name="slaveInstance"))
     py_type = FMI2PY[fmi_type]
     fmi_type_name = fmi_type.__qualname__.lower()
 

--- a/pythonfmu/tests/test_fmi2slave.py
+++ b/pythonfmu/tests/test_fmi2slave.py
@@ -15,6 +15,7 @@ PY2FMI = dict([(v, k) for k, v in FMI2PY.items()])
 
 @pytest.mark.parametrize("model", ["theModelName", None])
 def test_Fmi2Slave_constructor(model):
+
     class Slave(Fmi2Slave):
         modelName = model
 
@@ -68,6 +69,7 @@ def test_Fmi2Slave_getters(fmi_type, value):
     "hello_world",
 ])
 def test_Fmi2Slave_setters(fmi_type, value):
+
     class Slave(Fmi2Slave):
         def __init__(self, args):
             super().__init__(args)

--- a/pythonfmu/tests/test_fmi2slave.py
+++ b/pythonfmu/tests/test_fmi2slave.py
@@ -21,9 +21,6 @@ def test_Fmi2Slave_constructor(model):
 
         modelName = model
 
-        def __init__(self, instance_name):
-            super().__init__(instance_name)
-
         def do_step(self, t, dt):
             return True
 

--- a/pythonfmu/tests/test_fmi2slave.py
+++ b/pythonfmu/tests/test_fmi2slave.py
@@ -25,11 +25,11 @@ def test_Fmi2Slave_constructor(model):
             return True
 
     if model is None:
-        slave = Slave("slaveInstance")
+        slave = Slave(instance_name="slaveInstance")
         assert Slave.modelName == "Slave"
         assert slave.instance_name == "slaveInstance"
     else:
-        slave = Slave("slaveInstance")
+        slave = Slave(instance_name="slaveInstance")
         assert Slave.modelName == model
         assert slave.instance_name == "slaveInstance"
 
@@ -38,7 +38,7 @@ def test_Fmi2Slave_generation_tool():
         def do_step(self, t, dt):
             return True
     
-    slave = Slave("instance")
+    slave = Slave(instance_name="instance")
     xml = slave.to_xml()
 
     assert xml.attrib['generationTool'] == f"PythonFMU {VERSION}"
@@ -54,8 +54,8 @@ def test_Fmi2Slave_getters(fmi_type, value):
     
     class Slave(Fmi2Slave):
 
-        def __init__(self, instance_name):
-            super().__init__(instance_name)
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
             self.var = value
             self.register_variable(PY2FMI[type(value)]("var"))
 
@@ -65,7 +65,7 @@ def test_Fmi2Slave_getters(fmi_type, value):
     py_type = FMI2PY[fmi_type]
     fmi_type_name = fmi_type.__qualname__.lower()
 
-    slave = Slave("slaveInstance")
+    slave = Slave(instance_name="slaveInstance")
     if type(value) is py_type:
         assert getattr(slave, f"get_{fmi_type_name}")([0, ]) == [value, ]
     else:
@@ -84,15 +84,15 @@ def test_Fmi2Slave_setters(fmi_type, value):
 
     class Slave(Fmi2Slave):
 
-        def __init__(self, instance_name):
-            super().__init__(instance_name)
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
             self.var = None
             self.register_variable(PY2FMI[type(value)]("var"))
 
         def do_step(self, t, dt):
             return True
     
-    slave = Slave("slaveInstance")
+    slave = Slave(instance_name="slaveInstance")
     py_type = FMI2PY[fmi_type]
     fmi_type_name = fmi_type.__qualname__.lower()
 

--- a/pythonfmu/tests/test_integration.py
+++ b/pythonfmu/tests/test_integration.py
@@ -134,8 +134,8 @@ slave_class = "PythonSlaveWithDep"
 
 class PythonSlaveWithDep(Fmi2Slave):
 
-    def __init__(self, args):
-        super().__init__(args)
+    def __init__(self, instance_name):
+        super().__init__(instance_name)
 
         self.realIn = 22.0
         self.realOut = 0.0

--- a/pythonfmu/tests/test_integration.py
+++ b/pythonfmu/tests/test_integration.py
@@ -134,8 +134,8 @@ slave_class = "PythonSlaveWithDep"
 
 class PythonSlaveWithDep(Fmi2Slave):
 
-    def __init__(self, instance_name):
-        super().__init__(instance_name)
+    def __init__(self, args):
+        super().__init__(args)
 
         self.realIn = 22.0
         self.realOut = 0.0

--- a/pythonfmu/tests/test_integration.py
+++ b/pythonfmu/tests/test_integration.py
@@ -134,8 +134,8 @@ slave_class = "PythonSlaveWithDep"
 
 class PythonSlaveWithDep(Fmi2Slave):
 
-    def __init__(self, instance_name):
-        super().__init__(instance_name)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
         self.realIn = 22.0
         self.realOut = 0.0

--- a/pythonfmu/tests/test_integration.py
+++ b/pythonfmu/tests/test_integration.py
@@ -134,8 +134,8 @@ slave_class = "PythonSlaveWithDep"
 
 class PythonSlaveWithDep(Fmi2Slave):
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
 
         self.realIn = 22.0
         self.realOut = 0.0

--- a/pythonfmu/tests/test_variables.py
+++ b/pythonfmu/tests/test_variables.py
@@ -72,15 +72,15 @@ def test_ScalarVariable_start(var_type, value, causality, initial, variability):
 
     class PySlave(Fmi2Slave):
 
-        def __init__(self, instance_name):
-            super().__init__(instance_name)
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
             setattr(self, "var", value)
             self.register_variable(var_obj)
 
         def do_step(self, current_time: float, step_size: float):
             return True
 
-    slave = PySlave("testInstance")
+    slave = PySlave(instance_name="testInstance")
 
     xml = slave.to_xml()
     var_node = xml.find(".//ScalarVariable[@name='var']")

--- a/pythonfmu/tests/test_variables.py
+++ b/pythonfmu/tests/test_variables.py
@@ -72,15 +72,15 @@ def test_ScalarVariable_start(var_type, value, causality, initial, variability):
 
     class PySlave(Fmi2Slave):
 
-        def __init__(self, instance_name):
-            super().__init__(instance_name)
+        def __init__(self, args):
+            super().__init__(args)
             setattr(self, "var", value)
             self.register_variable(var_obj)
 
         def do_step(self, current_time: float, step_size: float):
             return True
 
-    slave = PySlave("testInstance")
+    slave = PySlave(dict(instance_name="slaveInstance"))
 
     xml = slave.to_xml()
     var_node = xml.find(".//ScalarVariable[@name='var']")

--- a/pythonfmu/tests/test_variables.py
+++ b/pythonfmu/tests/test_variables.py
@@ -80,7 +80,7 @@ def test_ScalarVariable_start(var_type, value, causality, initial, variability):
         def do_step(self, current_time: float, step_size: float):
             return True
 
-    slave = PySlave("slaveInstance")
+    slave = PySlave("testInstance")
 
     xml = slave.to_xml()
     var_node = xml.find(".//ScalarVariable[@name='var']")

--- a/pythonfmu/tests/test_variables.py
+++ b/pythonfmu/tests/test_variables.py
@@ -72,15 +72,15 @@ def test_ScalarVariable_start(var_type, value, causality, initial, variability):
 
     class PySlave(Fmi2Slave):
 
-        def __init__(self, args):
-            super().__init__(args)
+        def __init__(self, instance_name):
+            super().__init__(instance_name)
             setattr(self, "var", value)
             self.register_variable(var_obj)
 
         def do_step(self, current_time: float, step_size: float):
             return True
 
-    slave = PySlave(dict(instance_name="slaveInstance"))
+    slave = PySlave("slaveInstance")
 
     xml = slave.to_xml()
     var_node = xml.find(".//ScalarVariable[@name='var']")


### PR DESCRIPTION
~A bit ugly solution to #34. I was not able to use **kwargs from the C-API, so I use a dict object. This solution looks uglier in the Python API, but thats not the main use-case so..~

Now uses `*args, **kwargs` approach.

Closes #34 