### PR TITLE
WIP: Using subinterpreter

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -134,6 +134,6 @@ jobs:
           conda install -n test -c conda-forge pytest pyfmi fmpy
           cd python-wheel
           python -m pip install pythonfmu*.whl
-          python -m pytest --pyargs pythonfmu
+          python -m pytest --pyargs pythonfmu -sv
           cd ..
         shell: bash -l {0}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -131,7 +131,7 @@ jobs:
       - name: Run the Tests
         run: |
           conda activate test
-          conda install -n test -c conda-forge pytest pyfmi
+          conda install -n test -c conda-forge pytest pyfmi fmpy
           cd python-wheel
           python -m pip install pythonfmu*.whl
           python -m pytest --pyargs pythonfmu

--- a/pythonfmu/pythonfmu-export/headers/pythonfmu/PyState.hpp
+++ b/pythonfmu/pythonfmu-export/headers/pythonfmu/PyState.hpp
@@ -13,20 +13,56 @@ class PyState
 public:
     PyState()
     {
+        std::cout << "Creating PyState" << std::endl;
         _wasInitialized = Py_IsInitialized();
+        std::cout << "PyEval_ThreadsInitialized " << PyEval_ThreadsInitialized() << std::endl;
         if(!_wasInitialized){
+            std::cout << "Initialize Python" << std::endl;
+            Py_SetProgramName(L"./PythonFMU");
             Py_Initialize();
         }
+        std::cout << "Get main threads" << std::endl;
+        PyThreadState *mainstate = PyThreadState_Get();
+
+        std::cout << "Init threads" << std::endl;
+        PyEval_InitThreads();
+        PyEval_ReleaseThread(mainstate);
+        // std::cout << "Get GIL" << std::endl;
+        PyGILState_STATE gilstate = PyGILState_Ensure();
+
+        PyThreadState_Swap(NULL);
+        // std::cout << "New interpreter" << std::endl;
+        _fmustate = Py_NewInterpreter();
+
+        PyThreadState_Swap(mainstate);
+        PyGILState_Release(gilstate);
+
+        PyEval_RestoreThread(mainstate);
     }
 
     ~PyState()
     {
+        std::cout << "Cleaning PyState" << std::endl;
+        PyThreadState *mainstate = PyThreadState_Get();
+        PyEval_InitThreads();
+        PyEval_ReleaseThread(mainstate);
+        PyGILState_STATE gilstate = PyGILState_Ensure();
+
+        PyThreadState_Swap(_fmustate);
+        Py_EndInterpreter(_fmustate);
+
+        PyThreadState_Swap(mainstate);
+        PyGILState_Release(gilstate);
+
+        PyEval_RestoreThread(mainstate);
+
         if(!_wasInitialized){
             Py_Finalize();
         }
     }
 private:
     bool _wasInitialized;
+    PyThreadState *_fmustate;
 };
 
 } // namespace pythonfmu

--- a/pythonfmu/tests/test_integration.py
+++ b/pythonfmu/tests/test_integration.py
@@ -128,21 +128,21 @@ def test_integration_set(tmp_path):
         assert model_value == value
 
 # TODO fmpy generate a Segmentation fault at line PyObject* sys_module = PyImport_ImportModule("sys"); in PyObjectWrapper
-# @pytest.mark.integration
-# def test_simple_integration_fmpy(tmp_path):
-#     fmpy = pytest.importorskip(
-#         "fmpy", reason="fmpy is not available for testing the produced FMU"
-#     )
+@pytest.mark.integration
+def test_simple_integration_fmpy(tmp_path):
+    fmpy = pytest.importorskip(
+        "fmpy", reason="fmpy is not available for testing the produced FMU"
+    )
 
-#     script_file = Path(__file__).parent / DEMO
+    script_file = Path(__file__).parent / DEMO
 
-#     FmuBuilder.build_FMU(script_file, dest=tmp_path)
+    FmuBuilder.build_FMU(script_file, dest=tmp_path)
 
-#     fmu = tmp_path / "PythonSlave.fmu"
-#     assert fmu.exists()
-#     res = fmpy.simulate_fmu(str(fmu), stop_time=2.0)
+    fmu = tmp_path / "PythonSlave.fmu"
+    assert fmu.exists()
+    res = fmpy.simulate_fmu(str(fmu), stop_time=2.0)
 
-#     assert res["realOut"][-1] == pytest.approx(res["time"][-1], rel=1e-7)
+    assert res["realOut"][-1] == pytest.approx(res["time"][-1], rel=1e-7)
 
 
 @pytest.mark.integration


### PR DESCRIPTION
This trial introduces a subinterpreter.

But FMPy does not like that neither. Actually the error is out of my knowledge as Python is considered initialize but the main thread can not be captured. It may be related to `ctypes` (the intermediate library used by FMPy to all c dll) as it works for `pyfmi`.