### PR TITLE
Use str key for state and add integration test

### DIFF
--- a/pythonfmu/fmi2slave.py
+++ b/pythonfmu/fmi2slave.py
@@ -251,12 +251,12 @@ class Fmi2Slave(ABC):
                     f"Variable with valueReference={vr} is not of type String!"
                 )
 
-    def _get_fmu_state(self) -> Dict[int, Any]:
+    def _get_fmu_state(self) -> Dict[str, Any]:
         state = dict()
         for var in self.vars.values():
-            state[var.value_reference] = self.get_value(var.name)
+            state[var.name] = self.get_value(var.name)
         return state
 
-    def _set_fmu_state(self, state: Dict[int, Any]):
-        for vr, value in state.items():
-            self.set_value(self.vars[vr].name, value)
+    def _set_fmu_state(self, state: Dict[str, Any]):
+        for name, value in state.items():
+            self.set_value(name, value)


### PR DESCRIPTION
This PR changes the key for state used by `get/set_fmu_state` so that users may override `get_fmu_state` adding additional non-fmi variable type elements. 

Also adds integration tests for `get/set_fmu_state`