### PR TITLE
Fix fmpy use

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -97,7 +97,7 @@ jobs:
         uses: actions/cache@v1
         with:
           path: /usr/share/miniconda/pkgs
-          key: ${{ runner.os }}-test-cache-conda-pkgs-${{ matrix.python-version }}
+          key: ${{ runner.os }}-test-cache-conda-pkgs-${{ matrix.python-version }}-${{ hashFiles('environment.yml') }}
           restore-keys: |
             ${{ runner.os }}-test-cache-conda-pkgs-
             ${{ runner.os }}-test-
@@ -107,7 +107,7 @@ jobs:
         uses: actions/cache@v1
         with:
           path: /usr/share/miniconda/pkgs
-          key: ${{ runner.os }}-test-cache-conda-pkgs-${{ matrix.python-version }}
+          key: ${{ runner.os }}-test-cache-conda-pkgs-${{ matrix.python-version }}-${{ hashFiles('environment.yml') }}
           restore-keys: |
             ${{ runner.os }}-test-cache-conda-pkgs-
             ${{ runner.os }}-test-
@@ -117,7 +117,7 @@ jobs:
         uses: actions/cache@v1
         with:
           path: C:\Miniconda\pkgs
-          key: ${{ runner.os }}-test-cache-conda-pkgs-${{ matrix.python-version }}
+          key: ${{ runner.os }}-test-cache-conda-pkgs-${{ matrix.python-version }}-${{ hashFiles('environment.yml') }}
           restore-keys: |
             ${{ runner.os }}-test-cache-conda-pkgs-
             ${{ runner.os }}-test-
@@ -131,7 +131,8 @@ jobs:
       - name: Run the Tests
         run: |
           conda activate test
-          conda install -n test -c conda-forge pytest pyfmi
+          # Install test dependencies - update environment.yml if they changed
+          conda env update --name=test --file=environment.yml
           cd python-wheel
           python -m pip install pythonfmu*.whl
           python -m pytest --pyargs pythonfmu

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,6 +87,8 @@ jobs:
         python-version: [3.6, 3.7, 3.8]
     
     steps:
+      - uses: actions/checkout@v2
+
       - name: Download python package
         uses: actions/download-artifact@v1
         with:

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,6 @@
+channels:
+- conda-forge
+dependencies:
+- fmpy
+- pyfmi
+- pytest

--- a/pythonfmu/pythonfmu-export/cpp/PySlaveInstance.cpp
+++ b/pythonfmu/pythonfmu-export/cpp/PySlaveInstance.cpp
@@ -381,6 +381,8 @@ void PySlaveInstance::FreeFMUstate(fmi2FMUstate& state)
 
 size_t PySlaveInstance::SerializedFMUstateSize(const fmi2FMUstate& state)
 {
+    PyGILState_STATE gilstate = PyGILState_Ensure();
+
     auto pyState = reinterpret_cast<PyObject*>(state);
     PyObject* pyStateBytes = PyObject_CallMethod(pClass_, "_fmu_state_to_bytes", "(O)", pyState);
     if (pyStateBytes == nullptr) {
@@ -388,11 +390,16 @@ size_t PySlaveInstance::SerializedFMUstateSize(const fmi2FMUstate& state)
     }
     auto size = PyBytes_Size(pyStateBytes);
     Py_DECREF(pyStateBytes);
+
+    PyGILState_Release(gilstate);
+
     return size;
 }
 
 void PySlaveInstance::SerializeFMUstate(const fmi2FMUstate& state, fmi2Byte* bytes, size_t size)
 {
+    PyGILState_STATE gilstate = PyGILState_Ensure();
+
     auto pyState = reinterpret_cast<PyObject*>(state);
     PyObject* pyStateBytes = PyObject_CallMethod(pClass_, "_fmu_state_to_bytes", "(O)", pyState);
     if (pyStateBytes == nullptr) {
@@ -406,10 +413,14 @@ void PySlaveInstance::SerializeFMUstate(const fmi2FMUstate& state, fmi2Byte* byt
         bytes[i] = c[i];
     }
     Py_DECREF(pyStateBytes);
+
+    PyGILState_Release(gilstate);
 }
 
 void PySlaveInstance::DeSerializeFMUstate(const fmi2Byte bytes[], size_t size, fmi2FMUstate& state)
 {
+    PyGILState_STATE gilstate = PyGILState_Ensure();
+
     PyObject* pyStateBytes = PyBytes_FromStringAndSize(bytes, size);
     if (pyStateBytes == nullptr) {
         handle_py_exception("[DeSerializeFMUstate] PyBytes_FromStringAndSize");
@@ -420,6 +431,8 @@ void PySlaveInstance::DeSerializeFMUstate(const fmi2Byte bytes[], size_t size, f
     }
     state = reinterpret_cast<fmi2FMUstate*>(pyState);
     Py_DECREF(pyStateBytes);
+
+    PyGILState_Release(gilstate);
 }
 
 PySlaveInstance::~PySlaveInstance()

--- a/pythonfmu/pythonfmu-export/cpp/PySlaveInstance.cpp
+++ b/pythonfmu/pythonfmu-export/cpp/PySlaveInstance.cpp
@@ -28,7 +28,9 @@ PySlaveInstance::PySlaveInstance(std::string instanceName, std::string resources
     , visible_(visible)
 
 {
-    // Append resources path to python sys path
+    PyGILState_STATE gilstate = PyGILState_Ensure();
+
+    // Append resources path to python sys path    
     PyObject* sys_module = PyImport_ImportModule("sys");
     if (sys_module == nullptr) {
         handle_py_exception("[ctor] PyImport_ImportModule");
@@ -63,6 +65,8 @@ PySlaveInstance::PySlaveInstance(std::string instanceName, std::string resources
     }
 
     initialize();
+
+    PyGILState_Release(gilstate);
 }
 
 void PySlaveInstance::initialize()
@@ -84,58 +88,84 @@ void PySlaveInstance::initialize()
 
 void PySlaveInstance::SetupExperiment(cppfmu::FMIBoolean, cppfmu::FMIReal, cppfmu::FMIReal startTime, cppfmu::FMIBoolean, cppfmu::FMIReal)
 {
+    PyGILState_STATE gilstate = PyGILState_Ensure();
+
     auto f = PyObject_CallMethod(pInstance_, "setup_experiment", "(d)", startTime);
     if (f == nullptr) {
         handle_py_exception("[setupExperiment] PyObject_CallMethod");
     }
     Py_DECREF(f);
+
+    PyGILState_Release(gilstate);
 }
 
 void PySlaveInstance::EnterInitializationMode()
 {
+    PyGILState_STATE gilstate = PyGILState_Ensure();
+
     auto f = PyObject_CallMethod(pInstance_, "enter_initialization_mode", nullptr);
     if (f == nullptr) {
         handle_py_exception("[enterInitializationMode] PyObject_CallMethod");
     }
     Py_DECREF(f);
+
+    PyGILState_Release(gilstate);
 }
 
 void PySlaveInstance::ExitInitializationMode()
 {
+    PyGILState_STATE gilstate = PyGILState_Ensure();
+
     auto f = PyObject_CallMethod(pInstance_, "exit_initialization_mode", nullptr);
     if (f == nullptr) {
         handle_py_exception("[exitInitializationMode] PyObject_CallMethod");
     }
     Py_DECREF(f);
+
+    PyGILState_Release(gilstate);
 }
 
 bool PySlaveInstance::DoStep(cppfmu::FMIReal currentTime, cppfmu::FMIReal stepSize, cppfmu::FMIBoolean, cppfmu::FMIReal& endOfStep)
 {
+    PyGILState_STATE gilstate = PyGILState_Ensure();
+
     auto f = PyObject_CallMethod(pInstance_, "do_step", "(dd)", currentTime, stepSize);
     if (f == nullptr) {
         handle_py_exception("[doStep] PyObject_CallMethod");
     }
     bool status = static_cast<bool>(PyObject_IsTrue(f));
     Py_DECREF(f);
+
+    PyGILState_Release(gilstate);
+
     return status;
 }
 
 void PySlaveInstance::Reset()
 {
+    PyGILState_STATE gilstate = PyGILState_Ensure();
     initialize();
+
+    PyGILState_Release(gilstate);
 }
 
 void PySlaveInstance::Terminate()
 {
+    PyGILState_STATE gilstate = PyGILState_Ensure();
+
     auto f = PyObject_CallMethod(pInstance_, "terminate", nullptr);
     if (f == nullptr) {
         handle_py_exception("[terminate] PyObject_CallMethod");
     }
     Py_DECREF(f);
+
+    PyGILState_Release(gilstate);
 }
 
 void PySlaveInstance::SetReal(const cppfmu::FMIValueReference* vr, std::size_t nvr, const cppfmu::FMIReal* values)
 {
+    PyGILState_STATE gilstate = PyGILState_Ensure();
+
     PyObject* vrs = PyList_New(nvr);
     PyObject* refs = PyList_New(nvr);
     for (int i = 0; i < nvr; i++) {
@@ -150,10 +180,14 @@ void PySlaveInstance::SetReal(const cppfmu::FMIValueReference* vr, std::size_t n
         handle_py_exception("[setReal] PyObject_CallMethod");
     }
     Py_DECREF(f);
+
+    PyGILState_Release(gilstate);
 }
 
 void PySlaveInstance::SetInteger(const cppfmu::FMIValueReference* vr, std::size_t nvr, const cppfmu::FMIInteger* values)
 {
+    PyGILState_STATE gilstate = PyGILState_Ensure();
+
     PyObject* vrs = PyList_New(nvr);
     PyObject* refs = PyList_New(nvr);
     for (int i = 0; i < nvr; i++) {
@@ -168,10 +202,14 @@ void PySlaveInstance::SetInteger(const cppfmu::FMIValueReference* vr, std::size_
         handle_py_exception("[setInteger] PyObject_CallMethod");
     }
     Py_DECREF(f);
+
+    PyGILState_Release(gilstate);
 }
 
 void PySlaveInstance::SetBoolean(const cppfmu::FMIValueReference* vr, std::size_t nvr, const cppfmu::FMIBoolean* values)
 {
+    PyGILState_STATE gilstate = PyGILState_Ensure();
+
     PyObject* vrs = PyList_New(nvr);
     PyObject* refs = PyList_New(nvr);
     for (int i = 0; i < nvr; i++) {
@@ -186,10 +224,14 @@ void PySlaveInstance::SetBoolean(const cppfmu::FMIValueReference* vr, std::size_
         handle_py_exception("[setBoolean] PyObject_CallMethod");
     }
     Py_DECREF(f);
+
+    PyGILState_Release(gilstate);
 }
 
 void PySlaveInstance::SetString(const cppfmu::FMIValueReference* vr, std::size_t nvr, cppfmu::FMIString const* values)
 {
+    PyGILState_STATE gilstate = PyGILState_Ensure();
+
     PyObject* vrs = PyList_New(nvr);
     PyObject* refs = PyList_New(nvr);
     for (int i = 0; i < nvr; i++) {
@@ -204,10 +246,14 @@ void PySlaveInstance::SetString(const cppfmu::FMIValueReference* vr, std::size_t
         handle_py_exception("[setString] PyObject_CallMethod");
     }
     Py_DECREF(f);
+
+    PyGILState_Release(gilstate);
 }
 
 void PySlaveInstance::GetReal(const cppfmu::FMIValueReference* vr, std::size_t nvr, cppfmu::FMIReal* values) const
 {
+    PyGILState_STATE gilstate = PyGILState_Ensure();
+
     PyObject* vrs = PyList_New(nvr);
     for (int i = 0; i < nvr; i++) {
         PyList_SetItem(vrs, i, Py_BuildValue("i", vr[i]));
@@ -224,10 +270,14 @@ void PySlaveInstance::GetReal(const cppfmu::FMIValueReference* vr, std::size_t n
         values[i] = PyFloat_AsDouble(value);
     }
     Py_DECREF(refs);
+
+    PyGILState_Release(gilstate);
 }
 
 void PySlaveInstance::GetInteger(const cppfmu::FMIValueReference* vr, std::size_t nvr, cppfmu::FMIInteger* values) const
 {
+    PyGILState_STATE gilstate = PyGILState_Ensure();
+
     PyObject* vrs = PyList_New(nvr);
     for (int i = 0; i < nvr; i++) {
         PyList_SetItem(vrs, i, Py_BuildValue("i", vr[i]));
@@ -243,10 +293,14 @@ void PySlaveInstance::GetInteger(const cppfmu::FMIValueReference* vr, std::size_
         values[i] = static_cast<cppfmu::FMIInteger>(PyLong_AsLong(value));
     }
     Py_DECREF(refs);
+
+    PyGILState_Release(gilstate);
 }
 
 void PySlaveInstance::GetBoolean(const cppfmu::FMIValueReference* vr, std::size_t nvr, cppfmu::FMIBoolean* values) const
 {
+    PyGILState_STATE gilstate = PyGILState_Ensure();
+
     PyObject* vrs = PyList_New(nvr);
     for (int i = 0; i < nvr; i++) {
         PyList_SetItem(vrs, i, Py_BuildValue("i", vr[i]));
@@ -262,10 +316,14 @@ void PySlaveInstance::GetBoolean(const cppfmu::FMIValueReference* vr, std::size_
         values[i] = PyObject_IsTrue(value);
     }
     Py_DECREF(refs);
+
+    PyGILState_Release(gilstate);
 }
 
 void PySlaveInstance::GetString(const cppfmu::FMIValueReference* vr, std::size_t nvr, cppfmu::FMIString* values) const
 {
+    PyGILState_STATE gilstate = PyGILState_Ensure();
+
     PyObject* vrs = PyList_New(nvr);
     for (int i = 0; i < nvr; i++) {
         PyList_SetItem(vrs, i, Py_BuildValue("i", vr[i]));
@@ -281,30 +339,44 @@ void PySlaveInstance::GetString(const cppfmu::FMIValueReference* vr, std::size_t
         values[i] = PyBytes_AsString(PyUnicode_AsEncodedString(value, "utf-8", nullptr));
     }
     Py_DECREF(refs);
+
+    PyGILState_Release(gilstate);
 }
 
 void PySlaveInstance::GetFMUstate(fmi2FMUstate& state)
 {
+    PyGILState_STATE gilstate = PyGILState_Ensure();
+
     auto f = PyObject_CallMethod(pInstance_, "_get_fmu_state", nullptr);
     if (f == nullptr) {
         handle_py_exception("[_get_fmu_state] PyObject_CallMethod");
     }
     state = reinterpret_cast<fmi2FMUstate*>(f);
+
+    PyGILState_Release(gilstate);
 }
 
 void PySlaveInstance::SetFMUstate(const fmi2FMUstate& state)
 {
+    PyGILState_STATE gilstate = PyGILState_Ensure();
+
     auto pyState = reinterpret_cast<PyObject*>(state);
     auto f = PyObject_CallMethod(pInstance_, "_set_fmu_state", "(O)", pyState);
     if (f == nullptr) {
         handle_py_exception("[_set_fmu_state] PyObject_CallMethod");
     }
+
+    PyGILState_Release(gilstate);
 }
 
 void PySlaveInstance::FreeFMUstate(fmi2FMUstate& state)
 {
+    PyGILState_STATE gilstate = PyGILState_Ensure();
+
     auto f = reinterpret_cast<PyObject*>(state);
     Py_XDECREF(f);
+
+    PyGILState_Release(gilstate);
 }
 
 size_t PySlaveInstance::SerializedFMUstateSize(const fmi2FMUstate& state)
@@ -352,8 +424,12 @@ void PySlaveInstance::DeSerializeFMUstate(const fmi2Byte bytes[], size_t size, f
 
 PySlaveInstance::~PySlaveInstance()
 {
+    PyGILState_STATE gilstate = PyGILState_Ensure();
+
     Py_XDECREF(pClass_);
     Py_XDECREF(pInstance_);
+
+    PyGILState_Release(gilstate);
 }
 
 } // namespace pythonfmu

--- a/pythonfmu/pythonfmu-export/headers/pythonfmu/PyState.hpp
+++ b/pythonfmu/pythonfmu-export/headers/pythonfmu/PyState.hpp
@@ -13,56 +13,24 @@ class PyState
 public:
     PyState()
     {
-        std::cout << "Creating PyState" << std::endl;
         _wasInitialized = Py_IsInitialized();
-        std::cout << "PyEval_ThreadsInitialized " << PyEval_ThreadsInitialized() << std::endl;
+
         if(!_wasInitialized){
             std::cout << "Initialize Python" << std::endl;
             Py_SetProgramName(L"./PythonFMU");
             Py_Initialize();
         }
-        std::cout << "Get main threads" << std::endl;
-        PyThreadState *mainstate = PyThreadState_Get();
-
-        std::cout << "Init threads" << std::endl;
-        PyEval_InitThreads();
-        PyEval_ReleaseThread(mainstate);
-        // std::cout << "Get GIL" << std::endl;
-        PyGILState_STATE gilstate = PyGILState_Ensure();
-
-        PyThreadState_Swap(NULL);
-        // std::cout << "New interpreter" << std::endl;
-        _fmustate = Py_NewInterpreter();
-
-        PyThreadState_Swap(mainstate);
-        PyGILState_Release(gilstate);
-
-        PyEval_RestoreThread(mainstate);
     }
 
     ~PyState()
     {
-        std::cout << "Cleaning PyState" << std::endl;
-        PyThreadState *mainstate = PyThreadState_Get();
-        PyEval_InitThreads();
-        PyEval_ReleaseThread(mainstate);
-        PyGILState_STATE gilstate = PyGILState_Ensure();
-
-        PyThreadState_Swap(_fmustate);
-        Py_EndInterpreter(_fmustate);
-
-        PyThreadState_Swap(mainstate);
-        PyGILState_Release(gilstate);
-
-        PyEval_RestoreThread(mainstate);
-
         if(!_wasInitialized){
             Py_Finalize();
         }
     }
+
 private:
     bool _wasInitialized;
-    PyThreadState *_fmustate;
 };
 
 } // namespace pythonfmu

--- a/pythonfmu/pythonfmu-export/headers/pythonfmu/PyState.hpp
+++ b/pythonfmu/pythonfmu-export/headers/pythonfmu/PyState.hpp
@@ -13,20 +13,56 @@ class PyState
 public:
     PyState()
     {
+        std::cout << "Creating PyState" << std::endl;
         _wasInitialized = Py_IsInitialized();
+        std::cout << "PyEval_ThreadsInitialized " << PyEval_ThreadsInitialized() << std::endl;
         if(!_wasInitialized){
+            std::cout << "Initialize Python" << std::endl;
+            Py_SetProgramName(L"./PythonFMU");
             Py_Initialize();
         }
+        std::cout << "Get main threads" << std::endl;
+        PyThreadState *mainstate = PyThreadState_Get();
+
+        std::cout << "Init threads" << std::endl;
+        PyEval_InitThreads();
+        PyEval_ReleaseThread(mainstate);
+        // std::cout << "Get GIL" << std::endl;
+        PyGILState_STATE gilstate = PyGILState_Ensure();
+
+        PyThreadState_Swap(NULL);
+        // std::cout << "New interpreter" << std::endl;
+        _fmustate = Py_NewInterpreter();
+
+        PyThreadState_Swap(mainstate);
+        PyGILState_Release(gilstate);
+
+        PyEval_RestoreThread(mainstate);
     }
 
     ~PyState()
     {
+        std::cout << "Cleaning PyState" << std::endl;
+        PyThreadState *mainstate = PyThreadState_Get();
+        PyEval_InitThreads();
+        PyEval_ReleaseThread(mainstate);
+        PyGILState_STATE gilstate = PyGILState_Ensure();
+
+        PyThreadState_Swap(_fmustate);
+        Py_EndInterpreter(_fmustate);
+
+        PyThreadState_Swap(mainstate);
+        PyGILState_Release(gilstate);
+
+        PyEval_RestoreThread(mainstate);
+
         if(!_wasInitialized){
             Py_Finalize();
         }
     }
 private:
     bool _wasInitialized;
+    PyThreadState *_fmustate;
 };
 
 } // namespace pythonfmu

--- a/pythonfmu/pythonfmu-export/headers/pythonfmu/PyState.hpp
+++ b/pythonfmu/pythonfmu-export/headers/pythonfmu/PyState.hpp
@@ -20,19 +20,21 @@ public:
             Py_SetProgramName(L"./PythonFMU");
             Py_Initialize();
             PyEval_InitThreads();
-            PyThreadState* mainPyThread = PyEval_SaveThread();
+            _mainPyThread = PyEval_SaveThread();
         }
     }
 
     ~PyState()
     {
         if (!_wasInitialized) {
+            PyEval_RestoreThread(_mainPyThread);
             Py_Finalize();
         }
     }
 
 private:
     bool _wasInitialized;
+    PyThreadState* _mainPyThread;
 };
 
 } // namespace pythonfmu

--- a/pythonfmu/pythonfmu-export/headers/pythonfmu/PyState.hpp
+++ b/pythonfmu/pythonfmu-export/headers/pythonfmu/PyState.hpp
@@ -15,16 +15,18 @@ public:
     {
         _wasInitialized = Py_IsInitialized();
 
-        if(!_wasInitialized){
+        if (!_wasInitialized) {
             std::cout << "Initialize Python" << std::endl;
             Py_SetProgramName(L"./PythonFMU");
             Py_Initialize();
+            PyEval_InitThreads();
+            PyThreadState* mainPyThread = PyEval_SaveThread();
         }
     }
 
     ~PyState()
     {
-        if(!_wasInitialized){
+        if (!_wasInitialized) {
             Py_Finalize();
         }
     }

--- a/pythonfmu/pythonfmu-export/headers/pythonfmu/PyState.hpp
+++ b/pythonfmu/pythonfmu-export/headers/pythonfmu/PyState.hpp
@@ -16,7 +16,6 @@ public:
         _wasInitialized = Py_IsInitialized();
 
         if (!_wasInitialized) {
-            std::cout << "Initialize Python" << std::endl;
             Py_SetProgramName(L"./PythonFMU");
             Py_Initialize();
             PyEval_InitThreads();

--- a/pythonfmu/tests/test_integration.py
+++ b/pythonfmu/tests/test_integration.py
@@ -159,21 +159,21 @@ def test_integration_set(tmp_path):
         assert model_value == value
 
 # TODO fmpy generate a Segmentation fault at line PyObject* sys_module = PyImport_ImportModule("sys"); in PyObjectWrapper
-# @pytest.mark.integration
-# def test_simple_integration_fmpy(tmp_path):
-#     fmpy = pytest.importorskip(
-#         "fmpy", reason="fmpy is not available for testing the produced FMU"
-#     )
+@pytest.mark.integration
+def test_simple_integration_fmpy(tmp_path):
+    fmpy = pytest.importorskip(
+        "fmpy", reason="fmpy is not available for testing the produced FMU"
+    )
 
-#     script_file = Path(__file__).parent / DEMO
+    script_file = Path(__file__).parent / DEMO
 
-#     FmuBuilder.build_FMU(script_file, dest=tmp_path)
+    FmuBuilder.build_FMU(script_file, dest=tmp_path)
 
-#     fmu = tmp_path / "PythonSlave.fmu"
-#     assert fmu.exists()
-#     res = fmpy.simulate_fmu(str(fmu), stop_time=2.0)
+    fmu = tmp_path / "PythonSlave.fmu"
+    assert fmu.exists()
+    res = fmpy.simulate_fmu(str(fmu), stop_time=2.0)
 
-#     assert res["realOut"][-1] == pytest.approx(res["time"][-1], rel=1e-7)
+    assert res["realOut"][-1] == pytest.approx(res["time"][-1], rel=1e-7)
 
 
 @pytest.mark.integration

--- a/pythonfmu/tests/test_integration.py
+++ b/pythonfmu/tests/test_integration.py
@@ -158,7 +158,7 @@ def test_integration_set(tmp_path):
         
         assert model_value == value
 
-# TODO fmpy generate a Segmentation fault at line PyObject* sys_module = PyImport_ImportModule("sys"); in PyObjectWrapper
+
 @pytest.mark.integration
 def test_simple_integration_fmpy(tmp_path):
     fmpy = pytest.importorskip(

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ license = MIT
 license-file = LICENSE
 keywords = FMI
 classifiers = 
-	Development Status :: 2 - Pre-Alpha
+	Development Status :: 3 - Alpha
 	Intended Audience :: End Users/Desktop
 	Intended Audience :: Developers
 	Intended Audience :: Science/Research
@@ -25,6 +25,7 @@ classifiers =
 tests_require = 
 	pytest
 	pyfmi
+	fmpy
 
 [options]
 include_package_data = True
@@ -45,6 +46,7 @@ console_scripts =
 tests = 
 	pytest
 	pyfmi
+	fmpy
 
 [tool:pytest]
 markers =


### PR DESCRIPTION
This fix the ability to use the FMU with [FMPy](https://github.com/CATIA-Systems/FMPy) by handling correctly the GIL.

Not this does not use subinterpreter due to lack of knowledge on GIL and thread stuff in C-Python. See #52