### PR TITLE
Feature/no-class_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,6 @@ optional arguments:
 
 from pythonfmu import Fmi2Causality, Fmi2Slave, Boolean, Integer, Real, String
 
-slave_class = "PythonSlave"  # REQUIRED - Name of the class extending Fmi2Slave
-
 
 class PythonSlave(Fmi2Slave):
 

--- a/examples/demoslave.py
+++ b/examples/demoslave.py
@@ -1,7 +1,5 @@
 from pythonfmu import Fmi2Causality, Fmi2Variability, Fmi2Slave, Real
 
-slave_class = "Resistor"  # REQUIRED - Name of the class extending Fmi2Slave
-
 
 class Resistor(Fmi2Slave):
 

--- a/pythonfmu/builder.py
+++ b/pythonfmu/builder.py
@@ -4,6 +4,7 @@ import importlib
 import itertools
 import logging
 import platform
+import re
 import shutil
 import sys
 import tempfile
@@ -36,6 +37,12 @@ def get_lib_extension() -> str:
     return platforms.get(platform.system(), "")
 
 
+def get_class_name(file_name: Path) -> str:
+    with open(str(file_name), 'r') as file:
+        data = file.read()
+        return re.search('class (.*)\(\s*Fmi2Slave\s*\)\s*:', data).group(1)
+
+
 class ModelDescriptionFetcher:
     @staticmethod
     def get_model_description(filepath: Path, module_name: str) -> Tuple[str, Element]:
@@ -56,7 +63,7 @@ class ModelDescriptionFetcher:
             fmu_interface = importlib.util.module_from_spec(spec)
             spec.loader.exec_module(fmu_interface)
             # Instantiate the interface
-            class_name = getattr(fmu_interface, "slave_class")
+            class_name = get_class_name(filepath)
             instance = getattr(fmu_interface, class_name)(instance_name="dummyInstance")
         finally:
             sys.path.remove(str(filepath.parent))  # remove inserted temporary path

--- a/pythonfmu/builder.py
+++ b/pythonfmu/builder.py
@@ -40,7 +40,7 @@ def get_lib_extension() -> str:
 def get_class_name(file_name: Path) -> str:
     with open(str(file_name), 'r') as file:
         data = file.read()
-        return re.search('class (.*)\(\s*Fmi2Slave\s*\)\s*:', data).group(1)
+        return re.search('class (\w+)\(\s*Fmi2Slave\s*\)\s*:', data).group(1)
 
 
 class ModelDescriptionFetcher:

--- a/pythonfmu/pythonfmu-export/cpp/PySlaveInstance.cpp
+++ b/pythonfmu/pythonfmu-export/cpp/PySlaveInstance.cpp
@@ -75,8 +75,10 @@ PySlaveInstance::PySlaveInstance(std::string instanceName, std::string resources
 
         std::string className = findClassName(resources_ + "/" + moduleName + ".py");
         if (className.empty()) {
-            handle_py_exception("[ctor] findClassName", gilState);
+            cleanPyObject();
+            throw cppfmu::FatalError("Unable to find class extending Fmi2Slave!");
         }
+
         PyObject* pyClassName = Py_BuildValue("s", className.c_str());
         if (pyClassName == nullptr) {
             handle_py_exception("[ctor] Py_BuildValue", gilState);

--- a/pythonfmu/pythonfmu-export/cpp/PySlaveInstance.cpp
+++ b/pythonfmu/pythonfmu-export/cpp/PySlaveInstance.cpp
@@ -26,7 +26,7 @@ inline std::string findClassName(const std::string& fileName)
 {
     std::string line;
     std::ifstream infile(fileName);
-    std::string regexStr(R"(class (.*)\(\s*Fmi2Slave\s*\)\s*:)");
+    std::string regexStr(R"(^class (\w+)\(\s*Fmi2Slave\s*\)\s*:)");
     while (getline(infile, line)) {
         std::smatch m;
         std::regex re(regexStr);

--- a/pythonfmu/pythonfmu-export/cpp/PySlaveInstance.cpp
+++ b/pythonfmu/pythonfmu-export/cpp/PySlaveInstance.cpp
@@ -7,18 +7,34 @@
 
 #include <fstream>
 #include <functional>
+#include <regex>
 #include <sstream>
 #include <utility>
 
 namespace pythonfmu
 {
 
-inline std::string getLine(const std::string& fileName)
+inline std::string getline(const std::string& fileName)
 {
     std::string line;
     std::ifstream infile(fileName);
     std::getline(infile, line);
     return line;
+}
+
+inline std::string findClassName(const std::string& fileName)
+{
+    std::string line;
+    std::ifstream infile(fileName);
+    std::string regexStr(R"(class (.*)\(\s*Fmi2Slave\s*\)\s*:)");
+    while (getline(infile, line)) {
+        std::smatch m;
+        std::regex re(regexStr);
+        if (std::regex_search(line, m, re)) {
+            return m[1];
+        }
+    }
+    return "";
 }
 
 inline void py_safe_run(const std::function<void(PyGILState_STATE gilState)>& f)
@@ -51,22 +67,26 @@ PySlaveInstance::PySlaveInstance(std::string instanceName, std::string resources
             handle_py_exception("[ctor] PyList_Insert", gilState);
         }
 
-        std::string moduleName = getLine(resources_ + "/slavemodule.txt");
+        std::string moduleName = getline(resources_ + "/slavemodule.txt");
         PyObject* pModule = PyImport_ImportModule(moduleName.c_str());
         if (pModule == nullptr) {
             handle_py_exception("[ctor] PyImport_ImportModule", gilState);
         }
 
-        PyObject* className = PyObject_GetAttrString(pModule, "slave_class");
-        if (className == nullptr) {
-            handle_py_exception("[initialize] PyObject_GetAttrString", gilState);
+        std::string className = findClassName(resources_ + "/" + moduleName + ".py");
+        if (className.empty()) {
+            handle_py_exception("[ctor] findClassName", gilState);
+        }
+        PyObject* pyClassName = Py_BuildValue("s", className.c_str());
+        if (pyClassName == nullptr) {
+            handle_py_exception("[ctor] Py_BuildValue", gilState);
         }
 
-        pClass_ = PyObject_GetAttr(pModule, className);
-        Py_DECREF(className);
+        pClass_ = PyObject_GetAttr(pModule, pyClassName);
+        Py_DECREF(pyClassName);
         Py_DECREF(pModule);
         if (pClass_ == nullptr) {
-            handle_py_exception("[initialize] PyObject_GetAttr", gilState);
+            handle_py_exception("[ctor] PyObject_GetAttr", gilState);
         }
 
         initialize(gilState);

--- a/pythonfmu/tests/pythonslave.py
+++ b/pythonfmu/tests/pythonslave.py
@@ -1,7 +1,5 @@
 from pythonfmu.fmi2slave import Fmi2Slave, Fmi2Causality, Fmi2Variability, Integer, Real, Boolean, String
 
-slave_class = "PythonSlave"  # REQUIRED - Name of the class extending Fmi2Slave
-
 
 class PythonSlave(Fmi2Slave):
 

--- a/pythonfmu/tests/test_integration.py
+++ b/pythonfmu/tests/test_integration.py
@@ -249,8 +249,6 @@ def test_integration_has_local_dep(tmp_path):
 from pythonfmu.fmi2slave import Fmi2Slave, Fmi2Causality, Integer, Real, Boolean, String
 from localmodule import get_amplitude, get_time_constant
 
-slave_class = "PythonSlaveWithDep"
-
 
 class PythonSlaveWithDep(Fmi2Slave):
 
@@ -305,8 +303,6 @@ def test_integration_throw_py_error(tmp_path):
     )
 
     slave_code = """from pythonfmu.fmi2slave import Fmi2Slave, Fmi2Causality, Integer, Real, Boolean, String
-
-slave_class = "PythonSlaveWithException"
 
 
 class PythonSlaveWithException(Fmi2Slave):


### PR DESCRIPTION
This PR removes the requirement of declaring `class_name` in user scripts. It finds the class name using regex. 

A bit unsure about if the binder example should be updated at this point. Which version does it run?