### PR TITLE
WIP: Adding callbacks to transfer log message

### DIFF
--- a/pythonfmu/pythonfmu-export/CMakeLists.txt
+++ b/pythonfmu/pythonfmu-export/CMakeLists.txt
@@ -47,6 +47,7 @@ endif ()
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/headers)
 
 set(sources
+        headers/pythonfmu/callbacks.cpp
         cpp/cppfmu_cs.cpp
         cpp/fmi_functions.cpp
         cpp/PySlaveInstance.cpp

--- a/pythonfmu/pythonfmu-export/cpp/PySlaveInstance.cpp
+++ b/pythonfmu/pythonfmu-export/cpp/PySlaveInstance.cpp
@@ -480,7 +480,7 @@ cppfmu::UniquePtr<cppfmu::SlaveInstance> CppfmuInstantiateSlave(
     cppfmu::FMIBoolean visible,
     cppfmu::FMIBoolean,
     cppfmu::Memory memory,
-    const cppfmu::Logger&)
+    const cppfmu::Logger& logger)
 {
 
     auto resources = std::string(fmuResourceLocation);

--- a/pythonfmu/pythonfmu-export/cpp/fmi_functions.cpp
+++ b/pythonfmu/pythonfmu-export/cpp/fmi_functions.cpp
@@ -4,6 +4,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 #include "cppfmu/cppfmu_cs.hpp"
+#include "pythonfmu/callbacks.cpp"
 
 #include <exception>
 #include <limits>
@@ -71,6 +72,8 @@ fmi2Component fmi2Instantiate(
         if (fmuType != fmi2CoSimulation) {
             throw std::logic_error("Unsupported FMU instance type requested (only co-simulation is supported)");
         }
+        embedded_logger = functions;
+
         auto component = cppfmu::AllocateUnique<Component>(cppfmu::Memory{*functions},
             instanceName,
             *functions,

--- a/pythonfmu/pythonfmu-export/headers/pythonfmu/PyState.hpp
+++ b/pythonfmu/pythonfmu-export/headers/pythonfmu/PyState.hpp
@@ -5,6 +5,8 @@
 #include <Python.h>
 #include <iostream>
 
+#include "callbacks.cpp"
+
 namespace pythonfmu
 {
 
@@ -13,13 +15,25 @@ class PyState
 public:
     PyState()
     {
+        std::string module_name = "fmi2facade";
         was_initialized_ = Py_IsInitialized();
 
         if (!was_initialized_) {
+            PyImport_AppendInittab(module_name.c_str(), &PyInit_emb);
             Py_SetProgramName(L"./PythonFMU");
             Py_Initialize();
             PyEval_InitThreads();
             _mainPyThread = PyEval_SaveThread();
+        } else {
+            PyGILState_STATE gil_state = PyGILState_Ensure();
+
+            PyImport_AddModule(module_name.c_str());
+            PyObject* pyModule = PyInit_emb();
+            PyObject* sys_modules = PyImport_GetModuleDict();
+            PyDict_SetItemString(sys_modules, module_name.c_str(), pyModule);
+            Py_DECREF(pyModule);
+
+            PyGILState_Release(gil_state);
         }
     }
 

--- a/pythonfmu/pythonfmu-export/headers/pythonfmu/callbacks.cpp
+++ b/pythonfmu/pythonfmu-export/headers/pythonfmu/callbacks.cpp
@@ -13,7 +13,7 @@ extern "C" {
         if(!PyArg_ParseTuple(args, ":log"))
             return NULL;
         printf("before logger call");
-        embedded_logger->logger(NULL, instance_name, fmi2OK, "ok", "test log message");
+        embedded_logger->logger(NULL, "instanceName", fmi2OK, "ok", "test log message");
         
         Py_RETURN_NONE;
     }

--- a/pythonfmu/pythonfmu-export/headers/pythonfmu/callbacks.cpp
+++ b/pythonfmu/pythonfmu-export/headers/pythonfmu/callbacks.cpp
@@ -1,0 +1,50 @@
+#include <Python.h>
+#include <stdio.h>
+
+#include "cppfmu/cppfmu_common.hpp"
+
+extern "C" {
+    static const fmi2CallbackFunctions *embedded_logger;
+
+    static PyObject*
+    fmi2facade_log(PyObject *self, PyObject *args)
+    {
+        printf("in c code");
+        if(!PyArg_ParseTuple(args, ":log"))
+            return NULL;
+        printf("before logger call");
+        embedded_logger->logger(NULL, instance_name, fmi2OK, "ok", "test log message");
+        
+        Py_RETURN_NONE;
+    }
+
+    static PyObject*
+    fmi2facade_test(PyObject *self, PyObject *args)
+    {
+        const char *msg;
+        if(!PyArg_ParseTuple(args, "s:test", &msg))
+            return NULL;
+        printf("%s\n", msg);
+        
+        Py_RETURN_NONE;
+    }
+
+    static PyMethodDef EmbMethods[] = {
+        {"log", fmi2facade_log, METH_VARARGS,
+        "Return the number of arguments received by the process."},
+        {"test", fmi2facade_test, METH_VARARGS,
+        "Test Python callback function."},
+        {NULL, NULL, 0, NULL}
+    };
+
+    static PyModuleDef EmbModule = {
+        PyModuleDef_HEAD_INIT, "fmi2facade", NULL, -1, EmbMethods,
+        NULL, NULL, NULL, NULL
+    };
+
+    static PyObject*
+    PyInit_emb(void)
+    {
+        return PyModule_Create(&EmbModule);
+    }
+}

--- a/pythonfmu/tests/test_python_extension.py
+++ b/pythonfmu/tests/test_python_extension.py
@@ -1,0 +1,41 @@
+import pytest
+
+from pythonfmu import FmuBuilder
+
+
+@pytest.mark.integration
+def test_py_extension(tmp_path):
+    fmpy = pytest.importorskip(
+        "fmpy", reason="fmpy is not available for testing the produced FMU"
+    )
+
+    slave_code = """from pythonfmu.fmi2slave import Fmi2Slave, Fmi2Causality, Integer, Real, Boolean, String
+
+class PythonSlaveUsingExt(Fmi2Slave):
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+        self.realIn = 22.0
+        self.realOut = 0.0
+        self.register_variable(Real("realIn", causality=Fmi2Causality.input))
+        self.register_variable(Real("realOut", causality=Fmi2Causality.output))
+
+    def do_step(self, current_time, step_size):
+        import fmi2facade
+        print(fmi2facade.test("Passing message to c"))
+        print("before log")
+        print(fmi2facade.log())
+        return True
+"""
+
+    script_file = tmp_path / "orig" / "slavewithexception.py"
+    script_file.parent.mkdir(parents=True, exist_ok=True)
+    script_file.write_text(slave_code)
+
+    FmuBuilder.build_FMU(script_file, dest=tmp_path)
+
+    fmu = tmp_path / "PythonSlaveUsingExt.fmu"
+    assert fmu.exists()
+
+    fmpy.simulate_fmu(str(fmu), stop_time=0.1)


### PR DESCRIPTION
Fix #35 

@markaren I need your help on this one.

For passing the log message from Python to the FMU facade, it seems the best is to load a customized python module within the embedded python instance.

I defined such module in `pythonfmu/pythonfmu-export/headers/pythonfmu/callbacks.cpp`. The python module is called `fmi2facade` and has 2 functions: `test` and `log`. The first one receive a string from python and print it to stdout and in the second I'm trying to invoke the FMU logger.

The `test` function works as expected but the `log` function ends up with a `Segmentation fault`; you can try the unit test `pythonfmu/tests/test_python_extension.py`.

This is beyond my knowledge of C/C++. If by any chance you get some times to look into this, it will be great.

Note: I also have a problem on the best way to store the pointer to the logger function; using a static attribute does not look good.