### PR TITLE
FIX: changed find strategy of cmake for python

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, windows-2019]
+        os: [ubuntu-20.04, windows-2019]
     
     steps:
       - uses: actions/checkout@v2
@@ -83,10 +83,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, windows-2019]
+        os: [ubuntu-20.04, windows-2019]
         python-version: [3.7, 3.8, 3.9]
         exclude:
-          - os: ubuntu-18.04
+          - os: ubuntu-20.04
             python-version: 3.7
     timeout-minutes: 20
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, windows-2019]
+        os: [ubuntu-20.04, windows-2019]
     
     steps:
       - uses: actions/checkout@v2

--- a/pythonfmu/pythonfmu-export/CMakeLists.txt
+++ b/pythonfmu/pythonfmu-export/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.15)
 project(pythonfmu-export VERSION 0.2.0)
 
 # ==============================================================================
@@ -36,6 +36,7 @@ set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 # Force to use stable Python ABI https://docs.python.org/3/c-api/stable.html
 add_compile_definitions(Py_LIMITED_API)
 find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
+set(Python3_FIND_STRATEGY LOCATION)
 if (WIN32)
   set(Python3_LIBRARIES ${Python3_LIBRARY_DIRS}/python3.lib)
 endif ()


### PR DESCRIPTION
For the linux system, libpythonfmu-export.so has to be unique for every python version and readelf -d libpythonfmu-export.so should link to the corresponding python version (here: 3.7 )

 0x0000000000000001 (NEEDED)             Gemeinsame Bibliothek [**libpython3.7m.so.1.0**]
 0x0000000000000001 (NEEDED)             Gemeinsame Bibliothek [libstdc++.so.6]
 0x0000000000000001 (NEEDED)             Gemeinsame Bibliothek [libgcc_s.so.1]
 0x0000000000000001 (NEEDED)             Gemeinsame Bibliothek [libc.so.6]
 0x000000000000000e (SONAME)             soname der Bibliothek: [libpythonfmu-export.so]

NOTE: this fix requires CMAKE 3.15 ubuntu 20.04 ships with 3.16