### PR TITLE
Fix pythonfmu-export module on OSX

### DIFF
--- a/pythonfmu/pythonfmu-export/src/CMakeLists.txt
+++ b/pythonfmu/pythonfmu-export/src/CMakeLists.txt
@@ -26,10 +26,12 @@ target_include_directories(pythonfmu-export
         "${CMAKE_CURRENT_SOURCE_DIR}"
         )
 
-target_link_libraries(pythonfmu-export
-        PRIVATE
-        ${Python3_LIBRARIES}
-        )
+if (WIN32)
+  target_link_libraries(pythonfmu-export PRIVATE ${Python3_LIBRARIES})
+elseif (APPLE)
+  set_target_properties(pythonfmu-export PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
+endif ()
+# and on linux, dont link!
 
 if (WIN32)
   set_target_properties(pythonfmu-export


### PR DESCRIPTION
on Linux it should not be linked at all as symbols are loaded through the interpreter (same on MacOS but using a dedicated flag), linking is only required on Windows where undefined symbols are not allowed

Another possibility is linking to Python::Module, but it requires cmake>=3.24 (using Development.Module component) and that's a bit too recent

First l only wanted to help building on osx: see https://github.com/conda-forge/pythonfmu-feedstock/pull/13

Closes #187
(involuntary bonus :)


Maybe it will help for #152 too