### PR TITLE
Check for fmuexport binary

### DIFF
--- a/pythonfmu/__init__.py
+++ b/pythonfmu/__init__.py
@@ -4,3 +4,6 @@ from .enums import Fmi2Causality, Fmi2Initial, Fmi2Variability
 from .fmi2slave import Fmi2Slave
 from .variables import Boolean, Integer, Real, String
 from .default_experiment import DefaultExperiment
+
+if not FmuBuilder.has_binary():
+    raise ValueError("FmuBuilder binary is missing")


### PR DESCRIPTION
I also stumbled on #129, one possibility to address this is to raise at the import
Maybe we could also just send a warning message, maybe if there are legitimate uses of fmuexport that dont require the binary but I dont know

Closes #129