### PR TITLE
Drop Py_SetProgramName

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,7 +86,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, windows-2019]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: ['3.9', '3.11', '3.13']
     timeout-minutes: 15
 
     steps:

--- a/pythonfmu/pythonfmu-export/src/pythonfmu/PyState.hpp
+++ b/pythonfmu/pythonfmu-export/src/pythonfmu/PyState.hpp
@@ -48,7 +48,6 @@ namespace pythonfmu
             auto const mainPyThread = []() -> PyThreadState* {
                 auto const justInitialized = !Py_IsInitialized();
                 if (justInitialized) {
-                    Py_SetProgramName(L"./PythonFMU");
                     Py_Initialize();
 #if PY_VERSION_HEX < 0x03070000
                     PyEval_InitThreads();


### PR DESCRIPTION
This is deprecated from python>=3.11, it seems it doesnt hurt to remove it

Closes #186