### PR TITLE
CMake: Use Development.SABIModule

### DIFF
--- a/pythonfmu/pythonfmu-export/CMakeLists.txt
+++ b/pythonfmu/pythonfmu-export/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.18)
 project(pythonfmu-export VERSION 0.2.0)
 
 # ==============================================================================
@@ -34,10 +34,13 @@ set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 # ==============================================================================
 
 # Force to use stable Python ABI https://docs.python.org/3/c-api/stable.html
-add_compile_definitions(Py_LIMITED_API)
-find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
-if (WIN32)
-  set(Python3_LIBRARIES ${Python3_LIBRARY_DIRS}/python3.lib)
+option (USE_PYTHON_SABI "Use Python stable ABI" ON)
+if (USE_PYTHON_SABI AND CMAKE_VERSION VERSION_GREATER_EQUAL 3.26)
+  add_compile_definitions(Py_LIMITED_API)
+  find_package(Python3 REQUIRED COMPONENTS Development.SABIModule)
+  add_library (Python3::Module ALIAS Python3::SABIModule)
+else ()
+  find_package(Python3 REQUIRED COMPONENTS Development.Module)
 endif ()
 
 if (WIN32)

--- a/pythonfmu/pythonfmu-export/src/CMakeLists.txt
+++ b/pythonfmu/pythonfmu-export/src/CMakeLists.txt
@@ -20,18 +20,9 @@ set(sources
 add_library(pythonfmu-export ${sources} ${headers})
 target_compile_features(pythonfmu-export PUBLIC "cxx_std_17")
 
-target_include_directories(pythonfmu-export
-        PRIVATE
-        "${Python3_INCLUDE_DIRS}"
-        "${CMAKE_CURRENT_SOURCE_DIR}"
-        )
+target_include_directories(pythonfmu-export PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
 
-if (WIN32)
-  target_link_libraries(pythonfmu-export PRIVATE ${Python3_LIBRARIES})
-elseif (APPLE)
-  set_target_properties(pythonfmu-export PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
-endif ()
-# and on linux, dont link!
+target_link_libraries (pythonfmu-export PRIVATE Python3::Module)
 
 if (WIN32)
   set_target_properties(pythonfmu-export


### PR DESCRIPTION
This will use the new Python3::SABIModule target to use abi3 libs.
This fixes linking to actual stable lib on windows and avoid hardcoding osx link flags.
Also an option is introduced to choose stable abi or not (default is to use stable abi).
