### PR TITLE
Add dynamic optional typing import

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019]
+        os: [ubuntu-22.04, windows-2019]
     
     steps:
       - uses: actions/checkout@v3
@@ -85,7 +85,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, windows-2019]
+        os: [ubuntu-22.04, windows-2019]
         python-version: ['3.9', '3.11', '3.13']
     timeout-minutes: 15
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019]
+        os: [ubuntu-22.04, windows-2019]
     
     steps:
       - uses: actions/checkout@v2

--- a/pythonfmu/builder.py
+++ b/pythonfmu/builder.py
@@ -156,17 +156,7 @@ def update_model_parameters(src: Path, model: Fmi2Slave, newargs: dict) -> str:
     module_code = "".join(line for line in module_lines[0][: init_line - 1]) + from_init
 
     # Ensure that Optional is imported from typing.
-    # Check for an existing "from typing import ..." line, including multi-line imports.
-    typing_import_pattern = r"(?s)^(from\s+typing\s+import\s+)([\s\S]*?)(?=\n[^ \t]|$)"
-    match = re.search(typing_import_pattern, module_code, re.MULTILINE)
-    if match:
-        imports = match.group(2).replace("\n", "").replace("(", "").replace(")", "").strip()
-        if "Optional" not in [imp.strip() for imp in imports.split(",")]:
-            new_import_line = match.group(1) + imports + ", Optional"
-            module_code = module_code.replace(match.group(0), new_import_line, 1)
-    else:
-        # No import from typing exists, so prepend the required import.
-        module_code = "from typing import Optional\n" + module_code
+    module_code = "from typing import Optional\n" + module_code
 
     return module_code
 

--- a/pythonfmu/builder.py
+++ b/pythonfmu/builder.py
@@ -5,6 +5,7 @@ import argparse
 import importlib
 import itertools
 import logging
+import re
 import shutil
 import sys
 import tempfile
@@ -102,16 +103,16 @@ def get_model_class(src: Path) -> Fmi2Slave:
 def update_model_parameters(src: Path, model: Fmi2Slave, newargs: dict) -> str:
     """
     Update the model parameters in the __init__ function of a given module.
-    This function modifies the default values of the parameters in the __init__ 
-    function of the specified model with the new values provided in the newargs 
+    This function modifies the default values of the parameters in the __init__
+    function of the specified model with the new values provided in the newargs
     dictionary. It returns the updated module code as a string.
 
     Args:
         src (Path): The path to the source file containing the module.
-        model (Fmi2Slave): The model object whose __init__ function parameters 
+        model (Fmi2Slave): The model object whose __init__ function parameters
                            need to be updated.
-        newargs (dict): A dictionary containing the new parameter values. The 
-                        keys should be the parameter names and the values should 
+        newargs (dict): A dictionary containing the new parameter values. The
+                        keys should be the parameter names and the values should
                         be the new default values.
     Returns:
         str: The updated module code as a string.
@@ -143,7 +144,7 @@ def update_model_parameters(src: Path, model: Fmi2Slave, newargs: dict) -> str:
         else:
             par = pars[p]
         newpars.append(par)
-        signew = inspect.Signature(parameters=newpars)
+    signew = inspect.Signature(parameters=newpars)
 
     # Replace the signature of the __init__ function
     init_line = inspect.getsourcelines(init)[1]
@@ -153,7 +154,20 @@ def update_model_parameters(src: Path, model: Fmi2Slave, newargs: dict) -> str:
 
     from_init = from_init.replace(from_init[start - 1 : end], str(signew), 1)
     module_code = "".join(line for line in module_lines[0][: init_line - 1]) + from_init
-    
+
+    # Ensure that Optional is imported from typing.
+    # Check for an existing "from typing import ..." line.
+    typing_import_pattern = r"^(from\s+typing\s+import\s+)(.*)$"
+    match = re.search(typing_import_pattern, module_code, re.MULTILINE)
+    if match:
+        imports = match.group(2)
+        if "Optional" not in [imp.strip() for imp in imports.split(",")]:
+            new_import_line = match.group(1) + imports + ", Optional"
+            module_code = module_code.replace(match.group(0), new_import_line, 1)
+    else:
+        # No import from typing exists, so prepend the required import.
+        module_code = "from typing import Optional\n" + module_code
+
     return module_code
 
 def get_model_description(filepath: Path, module_name: str, class_name: str) -> Tuple[str, Element]:


### PR DESCRIPTION
This pull request introduces a minor enhancement to the `pythonfmu/builder.py` file by ensuring that the `Optional` type is properly imported when updating model parameters. Additionally, the `re` module is imported to facilitate this functionality.

* Implemented a check to ensure that the `Optional` type is imported from `typing`. If an existing `from typing import ...` line is found, it appends `Optional` if not already present; otherwise, it adds a new import statement at the beginning of the module code.