### PR TITLE
Changes to FmuBuilder.build_FMU. 1. Unload the script module after th…

### DIFF
--- a/pythonfmu/builder.py
+++ b/pythonfmu/builder.py
@@ -218,7 +218,9 @@ class FmuBuilder:
             raise ValueError(f"File {script_file!s} must have extension '.py'!")
         
         dest = Path(dest)
-        if dest.is_file() or (not dest.is_dir() and dest.suffix == '.fmu'): # explicit FMU file name is provided
+        if ( dest.suffix == '.fmu' and # explicit FMU file name shall always have suffix '.fmu'
+             ( dest.is_file() or # Note that .is_file() returns False if the file does not yet exist
+               not dest.is_dir())): # if dest represents an (existing) directory we cannot interpret as file!
             dest_file = dest
             dest = dest.parent
         else:


### PR DESCRIPTION
…e FMU is built to avoid that the cached script is used when using the FMU 2. Optionally allow non-default names for the resulting FMU file 3. Check that the script file is not among the project files 4. Add a documentation text to the function.